### PR TITLE
Removed duplicated keys in YAML files

### DIFF
--- a/delivery/CNABwithPorter/manifests/manifest.yaml
+++ b/delivery/CNABwithPorter/manifests/manifest.yaml
@@ -34,7 +34,6 @@ metadata:
   name: helloservice
   namespace: demospace
 spec:
-  type: ClusterIP
   selector:
     app: helloservice
   ports:

--- a/delivery/hello-operator/helm-charts/helloserver/templates/service.yaml
+++ b/delivery/hello-operator/helm-charts/helloserver/templates/service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: helloservice
   namespace: {{ .Release.Namespace }} 
 spec:
-  type: ClusterIP
   selector:
     app: helloservice
   ports:

--- a/delivery/keptn/helm-charts/helloserver/templates/service.yaml
+++ b/delivery/keptn/helm-charts/helloserver/templates/service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: helloservice
   namespace: {{ .Release.Namespace }} 
 spec:
-  type: ClusterIP
   selector:
     app: helloservice
   ports:


### PR DESCRIPTION
The `type` key was duplicated in some of the YAML files and has now been deleted.