### PR TITLE
Typo and wrong link location in KubeVela entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ currently supported:
 * [Helm-based operator deployment](/delivery/hello-operator/README.md)
 * [Multi-Stage delivery with Keptn](/delivery/keptn/README.md)
 * [CNAB with Porter air-gapped deployment](/delivery/CNABwithPorter/README.md)
-* [GitOps-based deployment using KubeVella](/delivery/KuubeVela/README.md)
+* [GitOps-based deployment using KubeVela](/delivery/KubeVela/README.md)
 
 Use cases supported going foward:
 


### PR DESCRIPTION
Fixed typo and location for the KubeVela README.md