### PR TITLE
changed manifests and other files to use ghcr.io as container registry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ application delivery. It - for sure - will grow over time. Right now you get the
 * A helm chart for the service and the deployment.
 * Three container images showing different versions
 
-  * aloisreitbauer/hello-server:v0.1.0
-  * aloisreitbauer/hello-server:v0.1.1
-  * aloisreitbauer/hello-server:v0.1.2
+  * ghcr.io/podtato-head/hello-server:v0.1.0
+  * ghcr.io/podtato-head/hello-server:v0.1.1
+  * ghcr.io/podtato-head/hello-server:v0.1.2
 
 ## Scenarios and Use Cases you can test with this repository
 

--- a/delivery/CNABwithPorter/manifests/manifest.yaml
+++ b/delivery/CNABwithPorter/manifests/manifest.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: aloisreitbauer/hello-server:latest
+        image: ghcr.io/podtato-head/hello-server:v0.1.1
         imagePullPolicy: Always
         ports:
         - containerPort: 9000

--- a/delivery/KubeVela/vela.yaml
+++ b/delivery/KubeVela/vela.yaml
@@ -2,7 +2,7 @@ name: helloservice
 
 services:
   server:
-    image: aloisreitbauer/hello-server:v0.1.1
+    image: ghcr.io/podtato-head/hello-server:v0.1.1
     port: 9000
     route:
       domain: example.com

--- a/delivery/charts/hello-server/values.yaml
+++ b/delivery/charts/hello-server/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: aloisreitbauer/hello-server
+  repository: ghcr.io/podtato-head/hello-server
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v0.1.0"

--- a/delivery/keptn/helm-charts/helloserver/values.yaml
+++ b/delivery/keptn/helm-charts/helloserver/values.yaml
@@ -1,2 +1,2 @@
-image: aloisreitbauer/hello-server:v0.1.2
+image: ghcr.io/podtato-head/hello-server:v0.1.2
 replicaCount: 1

--- a/hello-server/buildPush.sh
+++ b/hello-server/buildPush.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REPOSITORY="aloisreitbauer"
+REPOSITORY="ghcr.io/podtato-head/"
 
 TAG="0.1.0"
 


### PR DESCRIPTION
This PR fixes #15  to changes all container image references to ghcr.io/podtato-head