### PR TITLE
Changed Prometheus endpoint to /metrics

### DIFF
--- a/hello-server/helloserver.go
+++ b/hello-server/helloserver.go
@@ -132,7 +132,7 @@ func main() {
 		PathPrefix(staticDir).
 		Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
 
-	router.Path("/prometheus").Handler(promhttp.Handler())
+	router.Path("/metrics").Handler(promhttp.Handler())
 
 	fmt.Println("Serving requests on port 9000")
 	err := http.ListenAndServe(":9000", router)


### PR DESCRIPTION
Changing the Prometheus endpoint to `/metrics` according to the Prometheus documentation. The endpoint `/metrics` is also defaulted by the [Keptn Prometheus Services](https://github.com/keptn-contrib/prometheus-service/blob/master/deploy/service.yaml#L212). 

## Fixes issue
#26 