### PR TITLE
Update Keptn shipyard for v0.8.0

### DIFF
--- a/delivery/keptn/shipyard.yaml
+++ b/delivery/keptn/shipyard.yaml
@@ -1,12 +1,28 @@
-stages:
-  - name: "hardening"
-    approval_strategy:
-      pass: "automatic"
-      warning: "automatic"
-    deployment_strategy: "blue_green_service"
-    test_strategy: "performance"
-  - name: "production"
-    approval_strategy:
-      pass: "automatic"
-      warning: "manual"
-    deployment_strategy: "blue_green_service"
+apiVersion: "spec.keptn.sh/0.2.0"
+kind: "Shipyard"
+metadata:
+  name: "shipyard-sockshop"
+spec:
+  stages:
+    - name: "hardening"
+      sequences:
+        - name: "artifact-delivery"
+          tasks:
+            - name: "deployment"
+              properties:
+                deploymentstrategy: "blue_green_service"
+            - name: "test"
+              properties:
+                teststrategy: "performance"
+            - name: "evaluation"
+            - name: "release"
+    - name: "production"
+      sequences:
+        - name: "artifact-delivery"
+          triggers:
+            - "hardening.artifact-delivery.finished"
+          tasks:
+            - name: "deployment"
+              properties:
+                deploymentstrategy: "blue_green_service"
+            - name: "release"


### PR DESCRIPTION
Now that [Keptn v0.8.0](https://github.com/keptn/keptn/releases/tag/0.8.0) is released the shipyard needs to be updated to be compatible with the new Keptn version. More information about the new Keptn shipyard file can be found [here](https://keptn.sh/docs/0.8.x/continuous_delivery/multi_stage/#declare-shipyard-before-creating-a-project).