### PR TITLE
Fixed typo in buildcontainers action

### DIFF
--- a/.github/workflows/buildcontainers.yml
+++ b/.github/workflows/buildcontainers.yml
@@ -34,5 +34,5 @@ jobs:
       # Run script to build all container images
       - name: Create container images
         run: |
-          cd podtatoserver
+          cd podtato-server
           ./buildPush.sh


### PR DESCRIPTION
There is a typo in the `buildcontainers` action which prevents the action from completing successfully. 