### PR TITLE
Fixed image name in buildPush

### DIFF
--- a/podtato-server/buildPush.sh
+++ b/podtato-server/buildPush.sh
@@ -4,15 +4,15 @@ REPOSITORY="ghcr.io/podtato-head"
 
 TAG="0.1.0"
 
-docker build -f ./DockerfileV"${TAG}" . --tag "${REPOSITORY}"/podtato-server:v"${TAG}"
+docker build -f ./DockerfileV"${TAG}" . --tag "${REPOSITORY}"/podtatoserver:v"${TAG}"
 docker push "${REPOSITORY}"/podtatoserver:v"${TAG}"  
 
 TAG="0.1.1"
 
-docker build -f ./DockerfileV"${TAG}" . --tag "${REPOSITORY}"/podtato-server:v"${TAG}"
+docker build -f ./DockerfileV"${TAG}" . --tag "${REPOSITORY}"/podtatoserver:v"${TAG}"
 docker push "${REPOSITORY}"/podtatoserver:v"${TAG}"  
 
 TAG="0.1.2"
 
-docker build -f ./DockerfileV"${TAG}" . --tag "${REPOSITORY}"/podtato-server:v"${TAG}"
+docker build -f ./DockerfileV"${TAG}" . --tag "${REPOSITORY}"/podtatoserver:v"${TAG}"
 docker push "${REPOSITORY}"/podtatoserver:v"${TAG}"  


### PR DESCRIPTION
The container image names in the `buildPush.sh` file do not match and the [Github action](https://github.com/cncf/podtato-head/runs/2140717646?check_suite_focus=true#step:4:124) fails because of that. I omitted the `-` since other files already use the `podtatoserver` image name ([Example](https://github.com/cncf/podtato-head/blob/main/delivery/charts/podtatoserver/values.yaml#L8)). 