### PR TITLE
Fix HTML file path in Dockerfile

### DIFF
--- a/podtato-server/DockerfileV0.1.0
+++ b/podtato-server/DockerfileV0.1.0
@@ -1,7 +1,4 @@
-
 FROM golang:alpine AS builder
-
-LABEL org.opencontainers.image.source https://github.com/cncf-podtato-head
 
 # Set necessary environment variables needed for our image
 ENV GO111MODULE=on \
@@ -34,7 +31,7 @@ FROM scratch
 
 COPY --from=builder /dist/podtatoserver /
 COPY ./static  /static
-COPY ./overview.html  /overview.html
+COPY ./podtato-new.html  /podtato-new.html
 
 # Export necessary port
 EXPOSE 9000

--- a/podtato-server/DockerfileV0.1.1
+++ b/podtato-server/DockerfileV0.1.1
@@ -1,4 +1,3 @@
-
 FROM golang:alpine AS builder
 
 # Set necessary environment variables needed for our image
@@ -32,7 +31,7 @@ FROM scratch
 
 COPY --from=builder /dist/podtatoserver /
 COPY ./static  /static
-COPY ./overview.html  /overview.html
+COPY ./podtato-new.html  /podtato-new.html
 
 # Export necessary port
 EXPOSE 9000

--- a/podtato-server/DockerfileV0.1.2
+++ b/podtato-server/DockerfileV0.1.2
@@ -1,4 +1,3 @@
-
 FROM golang:alpine AS builder
 
 # Set necessary environment variables needed for our image
@@ -32,7 +31,7 @@ FROM scratch
 
 COPY --from=builder /dist/podtatoserver /
 COPY ./static  /static
-COPY ./overview.html  /overview.html
+COPY ./podtato-new.html  /podtato-new.html
 
 # Export necessary port
 EXPOSE 9000


### PR DESCRIPTION
The `podtatoserver.go` file refers to the [podtato-new.html](https://github.com/cncf/podtato-head/blob/main/podtato-server/podtatoserver.go#L84) file, but the Dockerfile copies `overview.html` which results in an error when accessing the site.