### PR TITLE
change type and port in Helm chart

### DIFF
--- a/delivery/keptn/helm-charts/helloserver/templates/service.yaml
+++ b/delivery/keptn/helm-charts/helloserver/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
     app: helloservice
   ports:
   - name: http
-    port: 9000
+    port: 80
     protocol: TCP
     targetPort: 9000
-  type: LoadBalancer
+  type: ClusterIP


### PR DESCRIPTION
- change `type` to `ClusterIP` to save loadbalancer resources (and service will be exposed via Istio Ingress anyway
- change service port to standard port 80 for Prometheus to query the metrics