### PR TITLE
Changed goroutines limit in slo file

### DIFF
--- a/delivery/keptn/slo.yaml
+++ b/delivery/keptn/slo.yaml
@@ -20,7 +20,7 @@ objectives:
   - sli: go_routines
     pass:
       - criteria:
-          - "<=20"
+          - "<=100"
 total_score:
   pass: "90%"
   warning: "75%"


### PR DESCRIPTION
The Keptn Quality gates failed on some occasions because the number of Goroutines was set to low in the SLO file. 