### PR TITLE
Jmeter testing config

### DIFF
--- a/delivery/keptn/jmeter/jmeter.conf.yaml
+++ b/delivery/keptn/jmeter/jmeter.conf.yaml
@@ -2,12 +2,12 @@
 spec_version: '0.1.0'
 workloads:
   - teststrategy: performance
-    vuser: 10
-    loopcount: 500
+    vuser: 50
+    loopcount: 10
     script: jmeter/load.jmx
     acceptederrorrate: 1.0
   - teststrategy: performance_light
     vuser: 50
-    loopcount: 10
+    loopcount: 5
     script: jmeter/load.jmx
     acceptederrorrate: 1.0


### PR DESCRIPTION
The performance testing strategy took a long time when testing the slow build version (10 minutes +), which is too long for an example application.