### PR TITLE
fix(build): failing build script path

### DIFF
--- a/.github/workflows/buildcontainers.yml
+++ b/.github/workflows/buildcontainers.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Create container images
         run: |
           cd podtato-server
-          ./buildPush.sh
+          ./scripts/buildPush.sh


### PR DESCRIPTION
I noticed github actions are failing after the merged PR with the folder directory changes.
This fixes that issue.
![Screenshot 2021-04-06 at 10 46 13](https://user-images.githubusercontent.com/1235925/113692561-91933700-96c5-11eb-91f6-7ee75a91ad4e.png)
