### PR TITLE
add KIND configuration

### DIFF
--- a/podtato-server/kind/README.md
+++ b/podtato-server/kind/README.md
@@ -1,0 +1,10 @@
+This is a configuration for Kind to be used for the podtato head examples
+
+You just need to run 
+
+```
+./fullInstall.sh
+```
+
+and you cluster with traefik will be setup automatically for you
+

--- a/podtato-server/kind/cluster.yaml
+++ b/podtato-server/kind/cluster.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 30080
+    hostPort: 30080
+    protocol: TCP
+  - containerPort: 30443
+    hostPort: 30443
+    protocol: TCP

--- a/podtato-server/kind/full_install.sh
+++ b/podtato-server/kind/full_install.sh
@@ -10,6 +10,6 @@ helm repo add traefik https://helm.traefik.io/traefik
 helm repo update
 helm install traefik traefik/traefik -f traefik_values.yaml
 
-echo "Exposing traefik dasboard"
+echo "Exposing traefik dashboard"
 
 kubectl apply -f ./traefik_dashboard.yaml

--- a/podtato-server/kind/full_install.sh
+++ b/podtato-server/kind/full_install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "Creating KIND cluster "
+
+kind create cluster --config=./cluster.yaml
+
+echo "Installing traefik"
+
+helm repo add traefik https://helm.traefik.io/traefik
+helm repo update
+helm install traefik traefik/traefik -f traefik_values.yaml
+
+echo "Exposing traefik dasboard"
+
+kubectl apply -f ./traefik_dashboard.yaml

--- a/podtato-server/kind/traefik_dashboard.yaml
+++ b/podtato-server/kind/traefik_dashboard.yaml
@@ -1,0 +1,14 @@
+# dashboard.yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: dashboard
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
+      kind: Rule
+      services:
+        - name: api@internal
+          kind: TraefikService

--- a/podtato-server/kind/traefik_values.yaml
+++ b/podtato-server/kind/traefik_values.yaml
@@ -1,0 +1,67 @@
+
+# Configure ports
+ports:
+  # The name of this one can't be changed as it is used for the readiness and
+  # liveness probes, but you can adjust its config to your liking
+  traefik:
+    port: 9000
+    # Use hostPort if set.
+    # hostPort: 9000
+    #
+    # Use hostIP if set. If not set, Kubernetes will default to 0.0.0.0, which
+    # means it's listening on all your interfaces and all your IPs. You may want
+    # to set this value if you need traefik to listen on specific interface
+    # only.
+    # hostIP: 192.168.100.10
+
+    # Override the liveness/readiness port. This is useful to integrate traefik
+    # with an external Load Balancer that performs healthchecks.
+    # healthchecksPort: 9000
+
+    # Defines whether the port is exposed if service.type is LoadBalancer or
+    # NodePort.
+    #
+    # You SHOULD NOT expose the traefik port on production deployments.
+    # If you want to access it from outside of your cluster,
+    # use `kubectl port-forward` or create a secure ingress
+    expose: true
+    exposedPort: 9000
+    protocol: TCP
+  web:
+    port: 8000
+    # hostPort: 8000
+    expose: true
+    exposedPort: 8000
+    protocol: TCP
+    nodePort: 30080
+  websecure:
+    port: 8443
+    # hostPort: 8443
+    expose: true
+    exposedPort: 8443
+    protocol: TCP
+    nodePort: 30443
+
+service:
+  enabled: true
+  type: NodePort
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This provides a KIND configuration to test the examples on your local machine. KIND is configured with NodePort and Ingress support using Traefik