### PR TITLE
fix(keptn): fixed wrong path to helm-chart and updated initProject.sh to work with keptn 0.8.6

### DIFF
--- a/delivery/keptn/README.md
+++ b/delivery/keptn/README.md
@@ -57,12 +57,12 @@ You can now login into Keptn portal.
 ./initProject.sh onboard-service
 ```
 
-### Deploy Service (new-artifact)
+### Deploy Service
 ```
 ./initProject.sh first-deploy-service
 ```
 
-### Upgrade Service (new-artifact)
+### Upgrade Service
 
 ```
 ./initProject.sh upgrade-service

--- a/delivery/keptn/initProject.sh
+++ b/delivery/keptn/initProject.sh
@@ -12,24 +12,24 @@ case "$1" in
     ;;
   "onboard-service")
     echo "Onboarding keptn service helloservice in project ${PROJECT}"
-    keptn onboard service helloservice --project="${PROJECT}" --chart=helm-charts/podtatoserver
+    keptn onboard service helloservice --project="${PROJECT}" --chart=helm-charts/helloserver
     ;;
   "first-deploy-service")
     echo "Deploying keptn service helloservice in project ${PROJECT}"
-    keptn send event new-artifact --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v0.1.1
+    keptn trigger delivery --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v0.1.1
     ;;
   "deploy-service")
     echo "Deploying keptn service helloservice in project ${PROJECT}"
-    echo keptn send event new-artifact --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v"${VERSION}"
-    keptn send event new-artifact --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v"${VERSION}"
+    echo keptn trigger delivery --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v"${VERSION}"
+    keptn trigger delivery --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v"${VERSION}"
     ;;    
   "upgrade-service")
     echo "Upgrading keptn service helloservice in project ${PROJECT}"
-    keptn send event new-artifact --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v0.1.0
+    keptn trigger delivery --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v0.1.0
     ;;
   "slow-build")
     echo "Deploying slow build version of helloservice in project ${PROJECT}"
-    keptn send event new-artifact --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v0.1.2
+    keptn trigger delivery --project="${PROJECT}" --service=helloservice --image="${IMAGE}" --tag=v0.1.2
     ;;
   "add-quality-gates")
     echo "Adding keptn quality-gates to project ${PROJECT}"


### PR DESCRIPTION
Fixes `Error: Provided Helm chart does not exist` when executing `./initProject.sh onboard-service`.

