### PR TITLE
(chore)helloservice: add label to the kubernetes service for podtato-head app

### DIFF
--- a/delivery/manifest/manifest.yaml
+++ b/delivery/manifest/manifest.yaml
@@ -35,6 +35,8 @@ kind: Service
 metadata:
   name: helloservice
   namespace: demospace
+  labels: 
+    app: helloservice
 spec:
   selector:
     app: helloservice


### PR DESCRIPTION
Adding a label to the kubernetes service of the podtato head app helps with setting up (prometheus) servicemonitors against it. 

Signed-off-by: ksatchit <karthik@chaosnative.com>