### PR TITLE
make GH action work in forks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,15 +20,18 @@ env:
 defaults:
   run:
     shell: bash
+
 jobs:
+
+  ################
+  ## gather info
+  ################
+
+  # prepare_ci_run gathers info about the commit
   prepare_ci_run:
     name: Prepare CI Run
-    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
-    # built afterwards (in other jobs that depend on this one).
     runs-on: ubuntu-20.04
     outputs: # declare what this job outputs (so it can be re-used for other jobs)
-      # build config
-      # metadata
       GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
       BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
       BRANCH_SLUG: ${{ steps.extract_branch.outputs.BRANCH_SLUG }}
@@ -60,6 +63,7 @@ jobs:
         uses: "WyriHaximus/github-action-next-semvers@v1.1"
         with:
           version: ${{ steps.get_previous_tag.outputs.tag }}
+
       - name: Get the version
         id: get_version
         env:
@@ -88,6 +92,7 @@ jobs:
           echo "VERSION=${VERSION}"
 
           echo "##[set-output name=VERSION;]$(echo ${VERSION})"
+
       - name: Get current date and time
         id: get_datetime
         run: |
@@ -95,12 +100,72 @@ jobs:
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
 
+  ##################
+  ## Verify code
+  ################## 
 
-  ############################################################################
-  # Build Container Images                                                   #
-  ############################################################################
-  container_build:
-    needs: [prepare_ci_run]
+  lint_go_code:
+    strategy:
+      matrix:
+        component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
+        version: [ "v1", "v2", "v3", "v4" ]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          working-directory: podtato-services/${{ matrix.component }}
+
+  ##################
+  ## Build images
+  ################## 
+
+  ## container_build_fork builds and pushes images from a fork
+  container_build_fork:
+    needs: [prepare_ci_run, lint_go_code]
+    strategy:
+      matrix:
+        component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
+        version: [ "v1", "v2", "v3", "v4" ]
+    runs-on: ubuntu-20.04
+    env:
+      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
+      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
+      DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
+      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Build for current fork
+        id: docker_build_fork
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            VERSION=${{ matrix.version }}
+          context: podtato-services/${{ matrix.component }}/.
+          push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
+          file: podtato-services/${{ matrix.component }}/docker/Dockerfile
+          platforms: linux/amd64
+          tags: |
+            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
+            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
+
+  ## container_build_main builds, signs, pushes, and scans images from main repo
+  container_build_main:
+    if: github.repository_owner == 'cncf'
+    needs: [prepare_ci_run,lint_go_code]
     strategy:
       matrix:
         component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
@@ -123,19 +188,12 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
+          registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ github.token }}
 
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.29
-          working-directory: podtato-services/${{ matrix.component }}
-
-      - name: Build
-        id: docker_build
+      - name: Build for main
+        id: docker_build_main
         uses: docker/build-push-action@v2
         with:
           build-args: |
@@ -164,55 +222,59 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: cosign sign -key .github/workflows/cosign.key -a GIT_HASH=${{ env.GIT_SHA }} -a VERSION=${{ needs.prepare_ci_run.outputs.VERSION }} ${{ env.CONTAINER_REGISTRY }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
 
+  ##################
+  ## Test deliveries
+  ##################
+
+  ## kubectl
+  ## TODO: enable this to work with containers built in a fork
+  ##       at the moment the image names are hard-coded to main's repos
+  ##       in the manifest
   test_kubectl_deployment:
     name: Test single kubectl deployment
-    needs: [prepare_ci_run, container_build]
-    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
-    # built afterwards (in other jobs that depend on this one).
-
+    needs: [prepare_ci_run, container_build_main]
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
 
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Create k8s Kind Cluster
+      - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
 
-      - name: Test Deployment (kubectl)
+      - name: Test delivery with kubectl
         run: |
-        
           namespace=podtato-kubectl
           sed "s/latest-dev/${{ env.VERSION }}/g" delivery/kubectl/manifest.yaml | kubectl apply -f -
-          kubectl get deployments -A -n ${namespace} -owide
-          kubectl wait --for=condition=ready pod --timeout=30s -l component -n ${namespace} 
+          kubectl get deployments --namespace=${namespace} --output wide
  
   test_helm_deployment:
-    name: Test Helm deployment
-    needs: [prepare_ci_run, container_build]
-    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
-    # built afterwards (in other jobs that depend on this one).
-
+    name: Test single Helm deployment
+    needs: [prepare_ci_run, container_build_fork]
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
 
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Create k8s Kind Cluster
+      - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
 
-      - name: Test Deployment (Helm)
+      - name: Test delivery with helm
         run: |
           namespace=podtato-helm
           kubectl create namespace ${namespace}
           kubectl config set-context --current --namespace=${namespace}
-          helm install podtato-head ./delivery/chart
-          kubectl get deployments -A -n ${namespace} -owide
-          kubectl wait --for=condition=ready pod --timeout=30s -l app.kubernetes.io/component -n ${namespace}
+          helm install podtato-head ./delivery/chart \
+            --set images.repositoryDirname=${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head
+          echo "----> main deployment:"
+          kubectl get deployment --selector 'app.kubernetes.io/component=podtato-head-main' --output yaml
+          echo "----> wait for ready"
+          kubectl wait --for=condition=ready pod --timeout=30s \
+            --selector app.kubernetes.io/component=podtato-head-main --namespace=${namespace}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'release-*'
-
   pull_request:
     branches:
       - 'main'
@@ -16,16 +15,12 @@ env:
   TRIVY_IGNORE_UNFIXED: true
   TRIVY_VULN_TYPE: 'os,library'
   TRIVY_SEVERITY: 'CRITICAL,HIGH'
-  
+
 defaults:
   run:
     shell: bash
 
 jobs:
-
-  ################
-  ## gather info
-  ################
 
   # prepare_ci_run gathers info about the commit
   prepare_ci_run:
@@ -40,30 +35,24 @@ jobs:
       DATE: ${{ steps.get_datetime.outputs.DATE }}
       TIME: ${{ steps.get_datetime.outputs.TIME }}
       DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
-
     steps:
       - name: Check out code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # need to checkout "all commits" for certain features to work (e.g., get all changed files)
-
       - name: Extract branch name
         id: extract_branch
-        # see https://github.com/keptn/gh-action-extract-branch-name for details
         uses: keptn/gh-action-extract-branch-name@main
-
       - name: 'Get Previous tag'
         id: get_previous_tag
         uses: "WyriHaximus/github-action-get-previous-tag@v1.1"
         with:
           fallback: "0.0.1"
-
       - name: 'Get next patch version'
         id: get_next_semver_tag
         uses: "WyriHaximus/github-action-next-semvers@v1.1"
         with:
           version: ${{ steps.get_previous_tag.outputs.tag }}
-
       - name: Get the version
         id: get_version
         env:
@@ -92,7 +81,6 @@ jobs:
           echo "VERSION=${VERSION}"
 
           echo "##[set-output name=VERSION;]$(echo ${VERSION})"
-
       - name: Get current date and time
         id: get_datetime
         run: |
@@ -100,10 +88,7 @@ jobs:
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
 
-  ##################
-  ## Verify code
-  ################## 
-
+  ## lint_go_code statically analyzes go code in the commit
   lint_go_code:
     strategy:
       matrix:
@@ -120,12 +105,8 @@ jobs:
           version: v1.29
           working-directory: podtato-services/${{ matrix.component }}
 
-  ##################
-  ## Build images
-  ################## 
-
-  ## container_build_fork builds and pushes images from a fork
-  container_build_fork:
+  ##  container_build builds and pushes images for any fork
+  container_build:
     needs: [prepare_ci_run, lint_go_code]
     strategy:
       matrix:
@@ -140,22 +121,19 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
-
-      - name: Build for current fork
+      - name: Build image and push to current fork
         id: docker_build_fork
         uses: docker/build-push-action@v2
         with:
           build-args: |
             VERSION=${{ matrix.version }}
           context: podtato-services/${{ matrix.component }}/.
-          push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
           file: podtato-services/${{ matrix.component }}/docker/Dockerfile
           platforms: linux/amd64
           tags: |
@@ -163,6 +141,8 @@ jobs:
             ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
 
   ## container_build_main builds, signs, pushes, and scans images from main repo
+  ## the repo path targeted by container_build_main doesn't include `cncf` in
+  ##   the path like the path for container_build
   container_build_main:
     if: github.repository_owner == 'cncf'
     needs: [prepare_ci_run,lint_go_code]
@@ -179,11 +159,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-
       - uses: sigstore/cosign-installer@main
         with:
           cosign-release: 'v1.0.0'
-
       - name: Login to GitHub Container Registry
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
         uses: docker/login-action@v1
@@ -191,7 +169,6 @@ jobs:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
-
       - name: Build for main
         id: docker_build_main
         uses: docker/build-push-action@v2
@@ -205,7 +182,6 @@ jobs:
           tags: |
             ${{ env.CONTAINER_REGISTRY }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
             ${{ env.CONTAINER_REGISTRY }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -215,66 +191,39 @@ jobs:
           ignore-unfixed: '${{ env.TRIVY_IGNORE_UNFIXED }}'
           vuln-type: '${{ env.TRIVY_VULN_TYPE }}'
           severity: '${{ env.TRIVY_SEVERITY }}'
-
       - name: Sign Container
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: cosign sign -key .github/workflows/cosign.key -a GIT_HASH=${{ env.GIT_SHA }} -a VERSION=${{ needs.prepare_ci_run.outputs.VERSION }} ${{ env.CONTAINER_REGISTRY }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
 
-  ##################
-  ## Test deliveries
-  ##################
-
-  ## kubectl
-  ## TODO: enable this to work with containers built in a fork
-  ##       at the moment the image names are hard-coded to main's repos
-  ##       in the manifest
-  test_kubectl_deployment:
-    name: Test single kubectl deployment
-    needs: [prepare_ci_run, container_build_main]
+  ## test kubectl
+  test_kubectl_delivery:
+    name: Deliver with kubectl
+    needs: [prepare_ci_run, container_build]
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
-
       - name: Checkout repo
         uses: actions/checkout@v2
-
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
-
       - name: Test delivery with kubectl
-        run: |
-          namespace=podtato-kubectl
-          sed "s/latest-dev/${{ env.VERSION }}/g" delivery/kubectl/manifest.yaml | kubectl apply -f -
-          kubectl get deployments --namespace=${namespace} --output wide
+        run: ./delivery/kubectl/test.sh "${{ github.repository_owner }}" "${{ env.VERSION }}"
  
-  test_helm_deployment:
-    name: Test single Helm deployment
-    needs: [prepare_ci_run, container_build_fork]
+  ## test helm
+  test_helm_delivery:
+    name: Deliver with Helm
+    needs: [prepare_ci_run, container_build]
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
-
       - name: Checkout repo
         uses: actions/checkout@v2
-
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
-
       - name: Test delivery with helm
-        run: |
-          namespace=podtato-helm
-          kubectl create namespace ${namespace}
-          kubectl config set-context --current --namespace=${namespace}
-          helm install podtato-head ./delivery/chart \
-            --set images.repositoryDirname=${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head
-          echo "----> main deployment:"
-          kubectl get deployment --selector 'app.kubernetes.io/component=podtato-head-main' --output yaml
-          echo "----> wait for ready"
-          kubectl wait --for=condition=ready pod --timeout=30s \
-            --selector app.kubernetes.io/component=podtato-head-main --namespace=${namespace}
+        run: ./delivery/chart/test.sh "${{ github.repository_owner }}" "${{ env.VERSION }}"

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ find delivery -type f -name "*.yaml" -print0 | xargs -0 sed -i 's/type: LoadBala
 
 ## Contributing
 
-If you are interested in contribution to podtato head please read [contributing.md](contributing.md)
+See [contributing.md](contributing.md).

--- a/contributing.md
+++ b/contributing.md
@@ -1,35 +1,59 @@
-# Contributing to podtato head
+# Contributing to podtato-head
 
+The purpose of podtato-head is to enable infrastructure and platform architects
+and engineers to try, compare, and contrast many options for delivering apps and
+their components to a Kubernetes cluster.
 
-## Contributing an implementation for a delivery tool
+Please keep this in mind as you develop new contributions! To make it easy for
+architects to try, compare and contrast, make sure the docs and tests for your
+delivery tool are similar to existing ones.
 
-If you want to create support for an additional delivery tool. Please create an issue and a PR with your changes. Currently we still need to manually verify if the use case working, so please test thoroughly.
+## Contribute a new delivery tool or service
 
-People are using these examples to learn how to use a delivery tool. Keep in mind that this will also be the (first) way they learn how to use your tool. Please write the examples with this in mind (explain what is created and why, ...) Each example should cover the following steps:
+To add a delivery tool or service to the repo, please create an issue to discuss
+and a PR with proposed changes. Each tool should get its own directory under
+`./delivery` with a README.md; look at existing tools and write something
+similar. Please also add a test for your tool in `.github/workflows/build.yaml`
+(a GitHub actions descriptor) following existing examples.
 
-* Setup and deployment of the delivery tool. Ideally, this can be done on a local machine with Kind, minikube, ...
-* Onboarding the podtato-head application. If you need specifc modifications from the standard manifest please describe them. 
-* Deploying the first version version of the service
-* Show how to access the service and validate whether it works
-* Show how to upgrade the service to a new version 
-* Show how to uninstall the everything again. Many people are using this for learning and want to get back to the before state easily. 
+### README details
 
-Additionally there are some more items you can provide to make your examples better:
+Include details in README.md to help architects and engineers trying the tool,
+such as the following:
 
-* Provide a command line script to run all the example steps. Most people copy and past them anyway. Going forward this will also help to automatically test the examples. The following format for a step works great as it output and executes a command. 
-  ``` 
-      if [$command -eq onboard] 
-        echo command_to_execute
-        command to execute
-      fi
+* Describe how to set up or deploy the tools or services. Please provide
+  something compatible with "local" clusters provided by kind, minikube, etc.
+* Describe how to set up the tool or service to deliver the podtato-head
+  application. If you make modifications from the base manifests and charts
+  describe them.
+* Describe how to actually deliver the podtato-head application.
+* Describe how to verify the delivery and verify functionality of the delivered app.
+* Describe how to upgrade to a new version using the tool, and/or how to
+  rollback.
+* Describe how to completely purge the podtato-head app and the delivery tools
+  and services from the cluster. Some folks need to return their cluster to a
+  pristine state!
+
+### Other suggestions
+
+* Provide a command line script to run all the example steps which users can copy and paste. You may use this as part of your test too. The following bash commands work as they echo then execute a command:
+  ```bash
+  if [ $command -eq onboard ] 
+      echo command_to_execute
+      command to execute
+  fi
   ```
- * Tell people where they can reach out. They might want to learn more about your tool. Make it easy for them. 
+ * Provide links to the tool's home page, issues page, and source repo. Help people find resources for their questions.
  * If you have a video walkthrough of the example - great!
 
-## Contributing to the podtato head app
+## Contribute to the podtato-head app
 
-If you have a new use cases in mind (e.g. adding an additonal service, ....) please create an issue and describe how the use case should work. As we want to keep the ``` main ``` branch as a working version we will create a decidated branch for new use cases. 
+If you have a new use cases in mind (e.g. adding an additonal service, ....)
+please create an issue and describe how the use case should work. As we want to
+keep the ``` main ``` branch as a working version we will create a dedicated
+branch for new use cases. 
 
 ## General discussion 
 
-For general discussions please join the CNCF podtato-head [Slack channel](https://cloud-native.slack.com/archives/C01NYM1S4LX) 
+For general discussions please join the CNCF podtato-head
+[Slack channel](https://cloud-native.slack.com/archives/C01NYM1S4LX).

--- a/delivery/chart/test.sh
+++ b/delivery/chart/test.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+
+github_user=${1:-cncf}
+# ci_version=${2:-latest-dev}
+
+this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+
+namespace=podtato-helm
+kubectl create namespace ${namespace} &> /dev/null
+kubectl config set-context --current --namespace=${namespace}
+
+helm install --debug podtato-head ${this_dir} \
+    --set "images.repositoryDirname=ghcr.io/${github_user}/podtato-head"
+
+echo ""
+echo "----> main deployment:"
+kubectl get deployment --selector 'app.kubernetes.io/component=podtato-head-main' --output yaml
+
+echo ""
+echo "----> wait for ready"
+kubectl wait --for=condition=ready pod --timeout=30s \
+    --selector app.kubernetes.io/component=podtato-head-main --namespace=${namespace}

--- a/delivery/kubectl/test.sh
+++ b/delivery/kubectl/test.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+github_user=${1:-cncf}
+ci_version=${2:-latest-dev}
+
+echo "ci_version: ${ci_version}, github_user: ${github_user}"
+
+this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+namespace=podtato-kubectl
+
+cat "${this_dir}/manifest.yaml" | \
+    sed "s@ghcr\.io\/podtato-head@ghcr.io/${github_user}/podtato-head@g" | \
+    sed "s/latest-dev/${ci_version}/g" | \
+        kubectl apply -f -
+
+kubectl wait --for=condition=Available deployment --namespace ${namespace} podtato-main
+
+kubectl get deployments --namespace=${namespace}


### PR DESCRIPTION
## What:

- adds a workflow job `build_container` which builds and pushes images to a repo accessible to the owner of the current fork
- renames the main container build job `build_container_main`
- updates `contributing.md` to reflect these changes
- uses `github.token` for the registry login rather than `secrets.CR_PAT`; the former is available in forks too, the latter isn't
- extracts tests for `kubectl` and `helm` into their directories and runs them from there in the workflow

## Why:

Without this, tests in forks can't use freshly built Go binaries and images because they don't have a registry to push to and pull from. As a result developers can't verify new functionality.

This also provides a framework for tests in each delivery directory.

Successful test run: <https://github.com/joshgav/podtato-head/actions/runs/1174710059>