### PR TITLE
use custom secret for main container build, add pull secret to test cluster

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,7 +168,7 @@ jobs:
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
+          password: ${{ secrets.CR_PAT }}
       - name: Build for main
         id: docker_build_main
         uses: docker/build-push-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -202,6 +202,7 @@ jobs:
     name: Deliver with kubectl
     needs: [prepare_ci_run, container_build]
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
@@ -210,7 +211,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
       - name: Test delivery with kubectl
-        run: ./delivery/kubectl/test.sh "${{ github.repository_owner }}" "${{ env.VERSION }}"
+        run: ./delivery/kubectl/test.sh "${{ github.repository_owner }}" "${{ github.token }}" "${{ env.VERSION }}"
  
   ## test helm
   test_helm_delivery:
@@ -226,4 +227,4 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
       - name: Test delivery with helm
-        run: ./delivery/chart/test.sh "${{ github.repository_owner }}" "${{ env.VERSION }}"
+        run: ./delivery/chart/test.sh "${{ github.repository_owner }}" "${{ github.token }}" "${{ env.VERSION }}"

--- a/delivery/chart/test.sh
+++ b/delivery/chart/test.sh
@@ -1,7 +1,8 @@
 #! /usr/bin/env bash
 
 github_user=${1:-cncf}
-# ci_version=${2:-latest-dev}
+github_token=${2}
+# ci_version=${3:-latest-dev}
 
 this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 
@@ -9,8 +10,14 @@ namespace=podtato-helm
 kubectl create namespace ${namespace} &> /dev/null
 kubectl config set-context --current --namespace=${namespace}
 
+kubectl create secret docker-registry ghcr \
+    --docker-server 'https://ghcr.io/' \
+    --docker-username "${github_user}" \
+    --docker-password "${github_token}"
+
 helm install --debug podtato-head ${this_dir} \
-    --set "images.repositoryDirname=ghcr.io/${github_user}/podtato-head"
+    --set "images.repositoryDirname=ghcr.io/${github_user}/podtato-head" \
+    --set "images.pullSecrets[0].name=ghcr"
 
 echo ""
 echo "----> main deployment:"

--- a/delivery/chart/test.sh
+++ b/delivery/chart/test.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -e
+
 github_user=${1:-cncf}
 github_token=${2}
 # ci_version=${3:-latest-dev}
@@ -7,17 +9,19 @@ github_token=${2}
 this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 
 namespace=podtato-helm
-kubectl create namespace ${namespace} &> /dev/null
+kubectl create namespace ${namespace} --save-config || true &> /dev/null
 kubectl config set-context --current --namespace=${namespace}
 
-kubectl create secret docker-registry ghcr \
-    --docker-server 'https://ghcr.io/' \
-    --docker-username "${github_user}" \
-    --docker-password "${github_token}"
+if [[ -n "${github_token}" ]]; then
+    kubectl create secret docker-registry ghcr \
+        --docker-server 'https://ghcr.io/' \
+        --docker-username "${github_user}" \
+        --docker-password "${github_token}"
+fi
 
-helm install --debug podtato-head ${this_dir} \
+helm upgrade --install --debug podtato-head ${this_dir} \
     --set "images.repositoryDirname=ghcr.io/${github_user}/podtato-head" \
-    --set "images.pullSecrets[0].name=ghcr"
+    ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
 
 echo ""
 echo "----> main deployment:"

--- a/delivery/kubectl/test.sh
+++ b/delivery/kubectl/test.sh
@@ -1,12 +1,21 @@
 #! /usr/bin/env bash
 
 github_user=${1:-cncf}
-ci_version=${2:-latest-dev}
+github_token=${2}
+ci_version=${3:-latest-dev}
 
 echo "ci_version: ${ci_version}, github_user: ${github_user}"
 
 this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 namespace=podtato-kubectl
+
+kubectl create secret docker-registry ghcr \
+    --docker-server 'https://ghcr.io/' \
+    --docker-username "${github_user}" \
+    --docker-password "${github_token}"
+
+kubectl patch serviceaccount default \
+    --patch '{ "imagePullSecrets": [{ "name": "ghcr" }]}'
 
 cat "${this_dir}/manifest.yaml" | \
     sed "s@ghcr\.io\/podtato-head@ghcr.io/${github_user}/podtato-head@g" | \

--- a/delivery/kubectl/test.sh
+++ b/delivery/kubectl/test.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -e
+
 github_user=${1:-cncf}
 github_token=${2}
 ci_version=${3:-latest-dev}
@@ -8,20 +10,25 @@ echo "ci_version: ${ci_version}, github_user: ${github_user}"
 
 this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 namespace=podtato-kubectl
+kubectl create namespace ${namespace} --save-config || true &> /dev/null
+kubectl config set-context --current --namespace ${namespace}
 
-kubectl create secret docker-registry ghcr \
-    --docker-server 'https://ghcr.io/' \
-    --docker-username "${github_user}" \
-    --docker-password "${github_token}"
+if [[ -n "${github_token}" ]]; then
+    kubectl create secret docker-registry ghcr \
+        --docker-server 'https://ghcr.io/' \
+        --docker-username "${github_user}" \
+        --docker-password "${github_token}"
 
-kubectl patch serviceaccount default \
-    --patch '{ "imagePullSecrets": [{ "name": "ghcr" }]}'
+    kubectl patch serviceaccount default \
+        --patch '{ "imagePullSecrets": [{ "name": "ghcr" }]}'
+fi
 
 cat "${this_dir}/manifest.yaml" | \
     sed "s@ghcr\.io\/podtato-head@ghcr.io/${github_user}/podtato-head@g" | \
     sed "s/latest-dev/${ci_version}/g" | \
         kubectl apply -f -
 
-kubectl wait --for=condition=Available deployment --namespace ${namespace} podtato-main
+kubectl wait --for=condition=Available --timeout=90s \
+    deployment --namespace ${namespace} podtato-main
 
 kubectl get deployments --namespace=${namespace}


### PR DESCRIPTION
### What

- Revert to custom secret for main container build since it pushes to `ghcr.io/podtato-head` and not `ghcr.io/cncf/podtato-head`.
- Add image pull secret for ghcr.io to kind cluster before delivering app.

### Why

Fixes #94 