### PR TITLE
demonstrate failed pull from ghcr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,6 +139,10 @@ jobs:
           tags: |
             ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
             ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
+      - name: Test pull
+        run: |
+          echo "---> test pull of image"
+          docker pull ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
 
   ## container_build_main builds, signs, pushes, and scans images from main repo
   ## the repo path targeted by container_build_main doesn't include `cncf` in

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to current fork
         id: docker_build_fork
         uses: docker/build-push-action@v2


### PR DESCRIPTION
This is to demonstrate that the same environment which pushes a fresh image to GHCR cannot pull it with the same credentials! I'm trying to figure out what could possibly be wrong, we'll know it's resolved when this works.