### PR TITLE
test main branch differently

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,6 +107,7 @@ jobs:
 
   ##  container_build builds and pushes images for any fork
   container_build:
+    if: github.repository_owner != 'cncf'
     needs: [prepare_ci_run, lint_go_code]
     strategy:
       matrix:
@@ -202,7 +203,7 @@ jobs:
     name: Deliver with kubectl
     needs: [prepare_ci_run, container_build]
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
+    # if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
@@ -218,7 +219,7 @@ jobs:
     name: Deliver with Helm
     needs: [prepare_ci_run, container_build]
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
+    # if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,21 +125,21 @@ jobs:
         with:
           cosign-release: 'v1.0.0'
       - name: Login to GitHub Container Registry
-        if: github.repository_owner == 'cncf'
+        if: github.repository_owner == 'cncf' || github.event.action == 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
       - name: Login to GitHub Container Registry
-        if: github.repository_owner != 'cncf'
+        if: github.repository_owner != 'cncf' && github.event.action != "pull_request"
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
       - name: Build for fork
-        if: github.repository_owner != 'cncf'
+        if: github.repository_owner != 'cncf' && github.event.action != "pull_request"
         id: docker_build_fork
         uses: docker/build-push-action@v2
         with:
@@ -152,7 +152,7 @@ jobs:
             ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
             ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
       - name: Build for main
-        if: github.repository_owner == 'cncf'
+        if: github.repository_owner == 'cncf' || github.event.action == 'pull_request'
         id: docker_build_main
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,21 +125,21 @@ jobs:
         with:
           cosign-release: 'v1.0.0'
       - name: Login to GitHub Container Registry
-        if: github.repository_owner == 'cncf' || github.event.action == 'pull_request'
+        if: github.repository_owner == 'cncf' || github.event.pull_request
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
       - name: Login to GitHub Container Registry
-        if: github.repository_owner != 'cncf' && github.event.action != "pull_request"
+        if: github.repository_owner != 'cncf' && ! github.event.pull_request
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
       - name: Build for fork
-        if: github.repository_owner != 'cncf' && github.event.action != "pull_request"
+        if: github.repository_owner != 'cncf' && ! github.event.pull_request
         id: docker_build_fork
         uses: docker/build-push-action@v2
         with:
@@ -152,7 +152,7 @@ jobs:
             ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
             ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
       - name: Build for main
-        if: github.repository_owner == 'cncf' || github.event.action == 'pull_request'
+        if: github.repository_owner == 'cncf' || github.event.pull_request
         id: docker_build_main
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,48 +105,9 @@ jobs:
           version: v1.29
           working-directory: podtato-services/${{ matrix.component }}
 
-  ##  container_build builds and pushes images for any fork
+  ## container_build builds, signs, pushes, and scans images
   container_build:
-    if: github.repository_owner != 'cncf'
     needs: [prepare_ci_run, lint_go_code]
-    strategy:
-      matrix:
-        component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
-        version: [ "v1", "v2", "v3", "v4" ]
-    runs-on: ubuntu-20.04
-    env:
-      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
-      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
-      DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
-      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.CONTAINER_REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
-      - name: Build image and push to current fork
-        id: docker_build_fork
-        uses: docker/build-push-action@v2
-        with:
-          build-args: |
-            VERSION=${{ matrix.version }}
-          context: podtato-services/${{ matrix.component }}/.
-          file: podtato-services/${{ matrix.component }}/docker/Dockerfile
-          platforms: linux/amd64
-          tags: |
-            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
-            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
-
-  ## container_build_main builds, signs, pushes, and scans images from main repo
-  ## the repo path targeted by container_build_main doesn't include `cncf` in
-  ##   the path like the path for container_build
-  container_build_main:
-    if: github.repository_owner == 'cncf'
-    needs: [prepare_ci_run,lint_go_code]
     strategy:
       matrix:
         component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
@@ -164,13 +125,34 @@ jobs:
         with:
           cosign-release: 'v1.0.0'
       - name: Login to GitHub Container Registry
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
+        if: github.repository_owner == 'cncf'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
+      - name: Login to GitHub Container Registry
+        if: github.repository_owner != 'cncf'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Build for fork
+        if: github.repository_owner != 'cncf'
+        id: docker_build_fork
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            VERSION=${{ matrix.version }}
+          context: podtato-services/${{ matrix.component }}/.
+          file: podtato-services/${{ matrix.component }}/docker/Dockerfile
+          platforms: linux/amd64
+          tags: |
+            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
+            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
       - name: Build for main
+        if: github.repository_owner == 'cncf'
         id: docker_build_main
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,34 +125,12 @@ jobs:
         with:
           cosign-release: 'v1.0.0'
       - name: Login to GitHub Container Registry
-        if: github.repository_owner == 'cncf' || github.event.pull_request
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
-      - name: Login to GitHub Container Registry
-        if: github.repository_owner != 'cncf' && ! github.event.pull_request
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.CONTAINER_REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
-      - name: Build for fork
-        if: github.repository_owner != 'cncf' && ! github.event.pull_request
-        id: docker_build_fork
-        uses: docker/build-push-action@v2
-        with:
-          build-args: |
-            VERSION=${{ matrix.version }}
-          context: podtato-services/${{ matrix.component }}/.
-          file: podtato-services/${{ matrix.component }}/docker/Dockerfile
-          platforms: linux/amd64
-          tags: |
-            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
-            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
       - name: Build for main
-        if: github.repository_owner == 'cncf' || github.event.pull_request
         id: docker_build_main
         uses: docker/build-push-action@v2
         with:

--- a/delivery/chart/test.sh
+++ b/delivery/chart/test.sh
@@ -14,14 +14,20 @@ kubectl config set-context --current --namespace=${namespace}
 
 if [[ -n "${github_token}" ]]; then
     kubectl create secret docker-registry ghcr \
-        --docker-server 'https://ghcr.io/' \
+        --docker-server 'ghcr.io' \
         --docker-username "${github_user}" \
         --docker-password "${github_token}"
 fi
 
-helm upgrade --install --debug podtato-head ${this_dir} \
-    --set "images.repositoryDirname=ghcr.io/${github_user}/podtato-head" \
-    ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
+if [[ "${github_user}" != "cncf" ]]; then
+    helm upgrade --install --debug podtato-head ${this_dir} \
+        --set "images.repositoryDirname=ghcr.io/${github_user}/podtato-head" \
+        ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
+else
+    helm upgrade --install --debug podtato-head ${this_dir} \
+        --set "images.repositoryDirname=ghcr.io/podtato-head" \
+        ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
+fi
 
 echo ""
 echo "----> main deployment:"

--- a/delivery/kubectl/test.sh
+++ b/delivery/kubectl/test.sh
@@ -23,12 +23,18 @@ if [[ -n "${github_token}" ]]; then
         --patch '{ "imagePullSecrets": [{ "name": "ghcr" }]}'
 fi
 
-cat "${this_dir}/manifest.yaml" | \
-    sed "s@ghcr\.io\/podtato-head@ghcr.io/${github_user}/podtato-head@g" | \
-    sed "s/latest-dev/${ci_version}/g" | \
-        kubectl apply -f -
+if [[ "${github_user}" != "cncf" ]]; then
+    cat "${this_dir}/manifest.yaml" | \
+        sed "s@ghcr\.io\/podtato-head@ghcr.io/${github_user}/podtato-head@g" | \
+        sed "s/latest-dev/${ci_version}/g" | \
+            kubectl apply -f -
+else
+    cat "${this_dir}/manifest.yaml" | \
+        sed "s/latest-dev/${ci_version}/g" | \
+            kubectl apply -f -
+fi
 
-kubectl wait --for=condition=Available --timeout=90s \
+kubectl wait --for=condition=Available --timeout=30s \
     deployment --namespace ${namespace} podtato-main
 
 kubectl get deployments --namespace=${namespace}


### PR DESCRIPTION
Giving up on using the same mechanism to test the current image in main and in forks per discussion in #97. Instead adding logic to use `ghcr.io/podtato-head` in main and `ghcr.io/<repository_owner>/podtato-head` in forks.