### PR TITLE
revert main workflow, add fork workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'release-*'
+
   pull_request:
     branches:
       - 'main'
@@ -16,18 +17,19 @@ env:
   TRIVY_IGNORE_UNFIXED: true
   TRIVY_VULN_TYPE: 'os,library'
   TRIVY_SEVERITY: 'CRITICAL,HIGH'
-
+  
 defaults:
   run:
     shell: bash
-
 jobs:
-
-  # prepare_ci_run gathers info about the commit
   prepare_ci_run:
     name: Prepare CI Run
+    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
+    # built afterwards (in other jobs that depend on this one).
     runs-on: ubuntu-20.04
     outputs: # declare what this job outputs (so it can be re-used for other jobs)
+      # build config
+      # metadata
       GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
       BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
       BRANCH_SLUG: ${{ steps.extract_branch.outputs.BRANCH_SLUG }}
@@ -36,19 +38,24 @@ jobs:
       DATE: ${{ steps.get_datetime.outputs.DATE }}
       TIME: ${{ steps.get_datetime.outputs.TIME }}
       DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # need to checkout "all commits" for certain features to work (e.g., get all changed files)
+
       - name: Extract branch name
         id: extract_branch
+        # see https://github.com/keptn/gh-action-extract-branch-name for details
         uses: keptn/gh-action-extract-branch-name@main
+
       - name: 'Get Previous tag'
         id: get_previous_tag
         uses: "WyriHaximus/github-action-get-previous-tag@v1.1"
         with:
           fallback: "0.0.1"
+
       - name: 'Get next patch version'
         id: get_next_semver_tag
         uses: "WyriHaximus/github-action-next-semvers@v1.1"
@@ -89,16 +96,38 @@ jobs:
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
 
-  ## lint_go_code statically analyzes go code in the commit
-  lint_go_code:
+
+  ############################################################################
+  # Build Container Images                                                   #
+  ############################################################################
+  container_build:
+    needs: [prepare_ci_run]
     strategy:
       matrix:
         component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
         version: [ "v1", "v2", "v3", "v4" ]
     runs-on: ubuntu-20.04
+    env:
+      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
+      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
+      DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
+      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+
+      - uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.0.0'
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
 
       - name: Lint
         uses: golangci/golangci-lint-action@v2
@@ -106,72 +135,8 @@ jobs:
           version: v1.29
           working-directory: podtato-services/${{ matrix.component }}
 
-  ##  container_build builds and pushes images for any fork
-  container_build:
-    needs: [prepare_ci_run, lint_go_code]
-    strategy:
-      matrix:
-        component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
-        version: [ "v1", "v2", "v3", "v4" ]
-    runs-on: ubuntu-20.04
-    env:
-      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
-      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
-      DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
-      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.CONTAINER_REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
-      - name: Build image and push to current fork
-        id: docker_build_fork
-        uses: docker/build-push-action@v2
-        with:
-          build-args: |
-            VERSION=${{ matrix.version }}
-          context: podtato-services/${{ matrix.component }}/.
-          file: podtato-services/${{ matrix.component }}/docker/Dockerfile
-          platforms: linux/amd64
-          tags: |
-            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-latest-dev
-            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
-
-  ## container_build_main builds, signs, pushes, and scans images from main repo
-  ## the repo path targeted by container_build_main doesn't include `cncf` in
-  ##   the path like the path for container_build
-  container_build_main:
-    if: github.repository_owner == 'cncf'
-    needs: [prepare_ci_run,lint_go_code]
-    strategy:
-      matrix:
-        component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
-        version: [ "v1", "v2", "v3", "v4" ]
-    runs-on: ubuntu-20.04
-    env:
-      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
-      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
-      DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
-      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.0.0'
-      - name: Login to GitHub Container Registry
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.CONTAINER_REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build for main
-        id: docker_build_main
+      - name: Build
+        id: docker_build
         uses: docker/build-push-action@v2
         with:
           build-args: |
@@ -206,40 +171,62 @@ jobs:
           ignore-unfixed: '${{ env.TRIVY_IGNORE_UNFIXED }}'
           vuln-type: '${{ env.TRIVY_VULN_TYPE }}'
           severity: '${{ env.TRIVY_SEVERITY }}'
+
       - name: Sign Container
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: cosign sign -key .github/workflows/cosign.key -a GIT_HASH=${{ env.GIT_SHA }} -a VERSION=${{ needs.prepare_ci_run.outputs.VERSION }} ${{ env.CONTAINER_REGISTRY }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version}}-${{ env.VERSION }}
 
-  ## test kubectl
-  test_kubectl_delivery:
-    name: Deliver with kubectl
+  test_kubectl_deployment:
+    name: Test single kubectl deployment
     needs: [prepare_ci_run, container_build]
+    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
+    # built afterwards (in other jobs that depend on this one).
+
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
-      - name: Checkout repo
+
+      - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Create kind cluster
+
+      - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
-      - name: Test delivery with kubectl
-        run: ./delivery/kubectl/test.sh "${{ github.repository_owner }}" "${{ github.token }}" "${{ env.VERSION }}"
+
+      - name: Test Deployment (kubectl)
+        run: |
+        
+          namespace=podtato-kubectl
+          sed "s/latest-dev/${{ env.VERSION }}/g" delivery/kubectl/manifest.yaml | kubectl apply -f -
+          kubectl get deployments -A -n ${namespace} -owide
+          kubectl wait --for=condition=ready pod --timeout=30s -l component -n ${namespace} 
  
-  ## test helm
-  test_helm_delivery:
-    name: Deliver with Helm
+  test_helm_deployment:
+    name: Test Helm deployment
     needs: [prepare_ci_run, container_build]
+    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
+    # built afterwards (in other jobs that depend on this one).
+
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-*' }}
     env:
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
     steps:
-      - name: Checkout repo
+
+      - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Create kind cluster
+
+      - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
-      - name: Test delivery with helm
-        run: ./delivery/chart/test.sh "${{ github.repository_owner }}" "${{ github.token }}" "${{ env.VERSION }}"
+
+      - name: Test Deployment (Helm)
+        run: |
+          namespace=podtato-helm
+          kubectl create namespace ${namespace}
+          kubectl config set-context --current --namespace=${namespace}
+          helm install podtato-head ./delivery/chart
+          kubectl get deployments -A -n ${namespace} -owide
+          kubectl wait --for=condition=ready pod --timeout=30s -l app.kubernetes.io/component -n ${namespace}

--- a/.github/workflows/fork-test.yaml
+++ b/.github/workflows/fork-test.yaml
@@ -1,0 +1,77 @@
+name: fork-build-and-test
+on:
+  push: {}
+  workflow_dispatch: {}
+env:
+  CONTAINER_REGISTRY: ghcr.io
+defaults:
+  run:
+    shell: bash
+jobs:
+  lint_go_code:
+    if: github.repository_owner != 'cncf'
+    strategy:
+      matrix:
+        component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
+        version: [ "v1", "v2", "v3", "v4" ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          working-directory: podtato-services/${{ matrix.component }}
+  build_images:
+    if: github.repository_owner != 'cncf'
+    needs: [lint_go_code]
+    strategy:
+      matrix:
+        component: [ "left-leg", "right-leg", "left-arm", "right-arm", "hats", "main" ]
+        version: [ "v1", "v2", "v3", "v4" ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Build image and push to current fork
+        id: docker_build_fork
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            VERSION=${{ matrix.version }}
+          context: podtato-services/${{ matrix.component }}/.
+          file: podtato-services/${{ matrix.component }}/docker/Dockerfile
+          platforms: linux/amd64
+          tags: |
+            ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/podtato-head/podtato-${{ matrix.component }}:${{ matrix.version }}-latest-dev
+  test_kubectl_delivery:
+    if: github.repository_owner != 'cncf'
+    name: Deliver with kubectl
+    needs: [build_images]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+      - name: Test delivery with kubectl
+        run: ./delivery/kubectl/test.sh "${{ github.repository_owner }}" "${{ github.token }}"
+  test_helm_delivery:
+    if: github.repository_owner != 'cncf'
+    name: Deliver with Helm
+    needs: [build_images]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+      - name: Test delivery with helm
+        run: ./delivery/chart/test.sh "${{ github.repository_owner }}" "${{ github.token }}"

--- a/delivery/chart/test.sh
+++ b/delivery/chart/test.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-github_user=${1:-cncf}
+github_user=${1}
 github_token=${2}
-# ci_version=${3:-latest-dev}
 
 this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 
@@ -12,7 +11,7 @@ namespace=podtato-helm
 kubectl create namespace ${namespace} --save-config || true &> /dev/null
 kubectl config set-context --current --namespace=${namespace}
 
-if [[ -n "${github_token}" ]]; then
+if [[ -n "${github_token}" && -n "${github_user}" ]]; then
     kubectl create secret docker-registry ghcr \
         --docker-server 'https://ghcr.io/' \
         --docker-username "${github_user}" \
@@ -20,7 +19,7 @@ if [[ -n "${github_token}" ]]; then
 fi
 
 helm upgrade --install --debug podtato-head ${this_dir} \
-    --set "images.repositoryDirname=ghcr.io/${github_user}/podtato-head" \
+    --set "images.repositoryDirname=ghcr.io/${github_user:+${github_user}/}podtato-head" \
     ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
 
 echo ""

--- a/delivery/kubectl/test.sh
+++ b/delivery/kubectl/test.sh
@@ -2,11 +2,10 @@
 
 set -e
 
-github_user=${1:-cncf}
+github_user=${1}
 github_token=${2}
-ci_version=${3:-latest-dev}
 
-echo "ci_version: ${ci_version}, github_user: ${github_user}"
+echo "github_user: ${github_user}"
 
 this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 namespace=podtato-kubectl
@@ -24,8 +23,7 @@ if [[ -n "${github_token}" ]]; then
 fi
 
 cat "${this_dir}/manifest.yaml" | \
-    sed "s@ghcr\.io\/podtato-head@ghcr.io/${github_user}/podtato-head@g" | \
-    sed "s/latest-dev/${ci_version}/g" | \
+    sed "s@ghcr\.io\/podtato-head@ghcr.io/${github_user:+${github_user}/}podtato-head@g" | \
         kubectl apply -f -
 
 kubectl wait --for=condition=Available --timeout=90s \


### PR DESCRIPTION
This reverts the main build workflow to the known-working state it was in in <https://github.com/cncf/podtato-head/commit/490a8ebc54e4b63c33babf383b5beadc3032d85e> plus additions from <https://github.com/cncf/podtato-head/commit/1a1647b6144e7259c2dfe06ed2b0981cb13e4781>.

It adds a _separate_ test for forks, which succeeded in my fork: <https://github.com/joshgav/podtato-head/actions/runs/1222555931>.

I believe this will finally fix #94. Thanks!