### PR TITLE
add os/arch support and fix the download url

### DIFF
--- a/scripts/requirements.sh
+++ b/scripts/requirements.sh
@@ -22,8 +22,37 @@ trivy --version
 ## cosign
 echo ""
 echo "installing cosign to ${install_dir}"
-cosign_version=v1.4.1
-curl -sSL -o "${install_dir}/cosign" https://storage.googleapis.com/cosign-releases/${cosign_version}/cosign-linux-amd64
+cosign_version=v2.2.0
+# give me the arch
+case "$(uname -m)" in
+    "x86_64")
+        arch="amd64"
+        ;;
+    "armv7l")
+        arch="arm"
+        ;;
+    "aarch64")
+        arch="arm64"
+        ;;
+    *)
+        echo "ERROR: unsupported architecture: $(uname -m)"
+        exit 1
+        ;;
+esac
+# give me the OS
+case "$(uname -s)" in
+    "Linux")
+        os="linux"
+        ;;
+    "Darwin")
+        os="darwin"
+        ;;
+    *)
+        echo "ERROR: unsupported OS: $(uname -s)"
+        exit 1
+        ;;
+esac
+curl -sSL -o "${install_dir}/cosign" https://github.com/sigstore/cosign/releases/download/${cosign_version}/cosign-${os}-${arch}
 chmod +x "${install_dir}/cosign"
 cosign version
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

> According to the announcement, [here](https://blog.sigstore.dev/cosign-releases-bucket-deprecation/). 

🚨 Sigstore announced that 𝑵𝒐 𝑳𝒐𝒏𝒈𝒆𝒓 𝑷𝒖𝒃𝒍𝒊𝒔𝒉𝒊𝒏𝒈 𝑪𝒐𝒔𝒊𝒈𝒏 𝑹𝒆𝒍𝒆𝒂𝒔𝒆𝒔 𝒕𝒐 𝑮𝑪𝑺 𝑩𝒖𝒄𝒌𝒆𝒕!
⚠️You should inspect any scripts or instructions where you may be downloading releases via the following URLs:
・❌gs://cosign-releases/
・❌https://storage.googleapis.com/cosign-releases/{version}/{artifact}
・❌https://cosign-releases.storage.googleapis.com/{version}/{artifact}
🌟Instead, you can download Cosign releases from Cosign’s GitHub repository. 
Please use↙️
・✅https://github.com/sigstore/cosign/releases/download/{version}/{artifact}

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->