### PR TITLE
update download link for cosign

### DIFF
--- a/scripts/requirements.sh
+++ b/scripts/requirements.sh
@@ -23,7 +23,7 @@ trivy --version
 echo ""
 echo "installing cosign to ${install_dir}"
 cosign_version=v1.4.1
-curl -sSL -o "${install_dir}/cosign" https://storage.googleapis.com/cosign-releases/${cosign_version}/cosign-linux-amd64
+curl -sSL -o "${install_dir}/cosign" https://github.com/sigstore/cosign/releases/download/${cosign_version}/cosign-linux-amd64
 chmod +x "${install_dir}/cosign"
 cosign version
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
Update link to download cosign

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
https://blog.sigstore.dev/cosign-releases-bucket-deprecation/ announced that Cosign downloads from the GCS bucket will no longer work after October 31, 2023. This PR updates the link to download from GitHub instead.